### PR TITLE
chore: pin pnpm to 11.1.0 + 7-day minimumReleaseAge

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,14 @@
   "engines": {
     "node": ">=22.18.0",
     "npm": "use pnpm",
-    "pnpm": ">=9",
+    "pnpm": ">=11",
     "yarn": "use pnpm"
+  },
+  "packageManager": "pnpm@11.1.0",
+  "pnpm": {
+    "minimumReleaseAge": 10080,
+    "minimumReleaseAgeExclude": [
+      "@openzeppelin/*"
+    ]
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1014,7 +1014,7 @@ packages:
     engines: {iojs: '>= 1.0.0', node: '>= 0.12.0'}
 
   code-style@https://codeload.github.com/OpenZeppelin/configs/tar.gz/a6cd128e6f5225b15d76704708c5def97caa8176:
-    resolution: {tarball: https://codeload.github.com/OpenZeppelin/configs/tar.gz/a6cd128e6f5225b15d76704708c5def97caa8176}
+    resolution: {gitHosted: true, tarball: https://codeload.github.com/OpenZeppelin/configs/tar.gz/a6cd128e6f5225b15d76704708c5def97caa8176}
     version: 0.1.0
 
   collect-v8-coverage@1.0.2:


### PR DESCRIPTION
## Summary

- Pins `packageManager: pnpm@11.1.0` (latest)
- Adds `engines.pnpm: ">=11"`
- Adds `pnpm.minimumReleaseAge: 10080` (= 7 days, in minutes)
- Adds `pnpm.minimumReleaseAgeExclude: ["@openzeppelin/*"]`

## Why

Supply-chain hardening response to the recent npm ecosystem incidents. `minimumReleaseAge` prevents pnpm from installing any package version published less than 7 days ago, giving compromised releases time to be detected and yanked before they land in our installs.

First-party `@openzeppelin/*` packages are excluded so internal releases continue to install immediately.

## Test plan

- [ ] CI passes with the new lockfile
- [ ] `pnpm install` works locally on a fresh clone
- [ ] No transitive resolution drift introduced by the pnpm 10 → 11 bump