### PR TITLE
ci: declare explicit GITHUB_TOKEN permissions in workflows

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -7,6 +7,10 @@ on:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   release:
     name: Release


### PR DESCRIPTION
The product-security baseline rollout will set the repository default `GITHUB_TOKEN` permissions to **read-only** (with PR-approval by the token disabled). Workflows that rely on the current implicit write default would start failing at their next write operation. This PR makes each workflow's required permissions explicit so the downgrade is a no-op for this repo.

| Workflow | Declared permissions |
|---|---|
| `.github/workflows/version.yml` | `contents: write`<br>`pull-requests: write` |

Not touched: `codeql.yml` (no top-level jobs: key found), `dependency-review.yml` (no top-level jobs: key found), `scorecard.yml` (no top-level jobs: key found)

Scopes were inferred from the actions and commands each workflow uses; read-only workflows get `contents: read`. Draft on purpose — please review before marking ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)